### PR TITLE
Support anonymous fields in go1.6 and later

### DIFF
--- a/typeinfo.go
+++ b/typeinfo.go
@@ -314,7 +314,7 @@ func (m *structCache) getFields(typ reflect.Type) fields {
 	for i := 0; i < numField; i++ {
 		f := typ.Field(i)
 
-		if f.PkgPath != "" {
+		if f.PkgPath != "" && !f.Anonymous {
 			continue
 		}
 


### PR DESCRIPTION
Currently libchan will not send anonymous fields when built with go1.6 and 1.7.  We tracked it down to this fork of msgpack.  There's a more detailed explantion here: https://tip.golang.org/doc/go1.6#reflect
